### PR TITLE
docker: default to listening on IPv6 as well

### DIFF
--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -2,7 +2,7 @@
 strict
 master
 die-on-term
-http-socket = :8000
+http-socket = [::]:8000
 harakiri = 10
 buffer-size = 32768
 post-buffering = 16192


### PR DESCRIPTION
When only a port is specified, uWSGI will only listen on the IPv4 wildcard (0.0.0.0) address. This will break environments relying on IPv6.

Use `http-socket = [::]:8000` to have uWSGI listen on IPv4 as well as IPv6.